### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,12 +4,16 @@
 | Name | GitHub |
 | --- | --- |
 | Andi Gunderson | agunde406 |
+| Peter Schwarz | peterschwarz |
+| Shawn Amundson | vaporos |
+
+### Emeritus Maintainers
+| Name | GitHub |
+| --- | --- |
 | Eloá Franca Verona | eloaverona |
 | James Mitchell | jsmitchell |
 | Logan Seeley | ltseeley |
-| Peter Schwarz | peterschwarz |
 | Richard Berg | rberg2 |
 | Ryan Beck-Buysse | rbuysse |
 | Ryan Banks | ryanlassigbanks |
 | Shannyn Telander | shannynalayna |
-| Shawn Amundson | vaporos |


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>